### PR TITLE
SDKCONFIG-21

### DIFF
--- a/lib/OneginiConfigModel.java
+++ b/lib/OneginiConfigModel.java
@@ -64,7 +64,13 @@ public class OneginiConfigModel implements OneginiClientConfigModel {
     return false;
   }
 
-  @Override
+  /**
+   * Get the max PIN failures. This attribute is just used for visual representation towards the end-user.
+   *
+   * @Deprecated Since Android SDK 6.01.00 this attribute is fetched from the Device config.
+   *
+   * @return The max PIN failures
+   */
   public int getMaxPinFailures() {
     return maxPinFailures;
   }

--- a/util/successMessage.go
+++ b/util/successMessage.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -28,7 +27,6 @@ func PrintSuccessMessage(config *Config, debugDetection bool, rootDetection bool
 	fmt.Printf("App Platform:		%v\n", config.Options.AppPlatform)
 	fmt.Printf("App Version:		%v\n", config.Options.AppVersion)
 	fmt.Printf("Redirect URI:		%v\n", config.Options.RedirectUrl)
-	fmt.Printf("Max PIN failures:	%v\n", strconv.Itoa(config.Options.MaxPinFailures))
 	fmt.Printf("Debug detection:	%v\n", debugDetection)
 	fmt.Printf("Root detection:		%v\n", rootDetection)
 	fmt.Printf("Token Server URI:	%v\n", config.Options.TokenServerUri)

--- a/util/writeConfigModel.go
+++ b/util/writeConfigModel.go
@@ -146,6 +146,8 @@ func overrideAndroidConfigModelValues(config *Config, keystorePath string, model
 		"resourceBaseURL": config.Options.ResourceGatewayUris[0],
 		"keystoreHash":    CalculateKeystoreHash(keystorePath),
 	}
+
+	// We might remove the maxPinFailures in a future release as it is no longer necessary for Android SDK versions > 6.00.01
 	intConfigMap := map[string]string{
 		"maxPinFailures": strconv.Itoa(config.Options.MaxPinFailures),
 	}


### PR DESCRIPTION
The getMaxPinFailures might no longer be part of the OneginiConfigModel

In a future release we will remove it but to remain backwards compatible with the Android SDK 6.00.01 release we only removed the @Override annotation that will cause compile issues. Depending on whether there are customers using the 6.00.01 release we will decide to remove the flag completely from the SDK configurator.