### PR TITLE
SDKCONFIG-28

### DIFF
--- a/lib/addFileToXcodeProject.rb
+++ b/lib/addFileToXcodeProject.rb
@@ -16,7 +16,7 @@ end
 
 # Add file to group
 file_refs = []
-file_ref = xcodeproj_group.files.find{|file|file.real_path.to_s==file_name}
+file_ref = xcodeproj_group.files.find{|file|file.real_path.to_s.include? file_name}
 unless file_ref
   file_ref = xcodeproj_group.new_file(file_name)
   file_refs<<file_ref

--- a/lib/removeFileFromXcodeProject.rb
+++ b/lib/removeFileFromXcodeProject.rb
@@ -13,7 +13,7 @@ xcodeproj_group = project.main_group[group_name]
 # Remove file from group
 if xcodeproj_group != nil
   xcodeproj_group.files.find{ |file|
-    if file.real_path.to_s==file_name
+    if file.real_path.to_s.include? file_name
       file.referrers.each do |ref|
         if ref.isa == "PBXBuildFile"
           ref.remove_from_project


### PR DESCRIPTION
In case the SDK configurator is triggered with '.' as app-dir param
the real_path is a relative path instead of full path. The file_name is
always the full path to the file.